### PR TITLE
Use SCSS global stylesheet in layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
+import "./globals.scss";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",


### PR DESCRIPTION
## Summary
- switch layout from importing `globals.css` to `globals.scss`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68971e92f5f88328856c1e1dd0e8f0f3