### PR TITLE
fix: correct search results import paths

### DIFF
--- a/app/[type]/[sale]/[location]/page.tsx
+++ b/app/[type]/[sale]/[location]/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
-import '../../globals.scss';
-import '../../search-results.scss';
+import '../../../globals.scss';
+import '../../../search-results.scss';
 
 interface Params {
   type: string;


### PR DESCRIPTION
## Summary
- fix relative paths for global and search-results styles in search results page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68971fab91608328bf69d144255ea6d5