### PR TITLE
fix: correct nested details page imports

### DIFF
--- a/app/[type]/[sale]/[location]/[address]/loading.tsx
+++ b/app/[type]/[sale]/[location]/[address]/loading.tsx
@@ -1,5 +1,5 @@
-import '../../../globals.scss';
-import '../../../details-page.scss';
+import '../../../../globals.scss';
+import '../../../../details-page.scss';
 
 export default function Loading() {
   return (

--- a/app/[type]/[sale]/[location]/[address]/page.tsx
+++ b/app/[type]/[sale]/[location]/[address]/page.tsx
@@ -1,5 +1,5 @@
-import '../../../globals.scss';
-import '../../../details-page.scss';
+import '../../../../globals.scss';
+import '../../../../details-page.scss';
 
 interface Params {
   type: string;


### PR DESCRIPTION
## Summary
- fix relative import paths in address page components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68972082128c8328a5e9b39ab5263393