### PR TITLE
Make dynamic route pages async

### DIFF
--- a/app/[type]/[sale]/[location]/[address]/page.tsx
+++ b/app/[type]/[sale]/[location]/[address]/page.tsx
@@ -8,8 +8,12 @@ interface Params {
   address: string;
 }
 
-export default function DetailsPage({ params }: { params: Params }) {
-  const { type, sale, location, address } = params;
+export default async function DetailsPage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { type, sale, location, address } = await params;
 
   // Replace this with a real fetch.
   const property = {

--- a/app/[type]/[sale]/[location]/page.tsx
+++ b/app/[type]/[sale]/[location]/page.tsx
@@ -8,8 +8,12 @@ interface Params {
   location: string;
 }
 
-export default function SearchResultsPage({ params }: { params: Params }) {
-  const { type, sale, location } = params;
+export default async function SearchResultsPage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { type, sale, location } = await params;
 
   // Dummy data—replace with a real fetch call.
   const listings = [


### PR DESCRIPTION
## Summary
- Mark dynamic route pages as `async`
- Accept `Promise<Params>` and await to access route params

## Testing
- `yarn lint`
- `npx tsc -p tsconfig.json`
- `yarn build` *(fails: Failed to fetch `Geist` and `Geist Mono` fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6897237318d48328a6d023cb7894b612